### PR TITLE
ci: use github-hosted runners after transfer

### DIFF
--- a/.github/workflows/main-tests.yml
+++ b/.github/workflows/main-tests.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    runs-on: [self-hosted, self-hosted-gregor]
+    runs-on: ubuntu-latest
 
     services:
       kurrent:
@@ -27,6 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - uses: Swatinem/rust-cache@v2
 
       - name: Build


### PR DESCRIPTION
Moves workflow jobs off the old `self-hosted-gregor` runner label after the
repository transfer back to `jwilger`.

The personal-account repos do not have repo-level self-hosted runners registered,
so jobs using that label remain queued indefinitely. This switches those jobs to
GitHub-hosted `ubuntu-latest` runners.

For workflows that invoke `nix develop`, this also adds the existing repo
convention:

- `DeterminateSystems/nix-installer-action@v22`
- `DeterminateSystems/magic-nix-cache-action@v14`

Local validation:

- `git diff --check`
- YAML parse for all workflow files
- `actionlint`
